### PR TITLE
Fix error when building on OS X

### DIFF
--- a/scripts/Kbuild.include
+++ b/scripts/Kbuild.include
@@ -100,7 +100,7 @@ as-option = $(call try-run,\
 # Usage: cflags-y += $(call as-instr,instr,option1,option2)
 
 as-instr = $(call try-run,\
-	/bin/echo -e "$(1)" | $(CC) $(KBUILD_AFLAGS) -c -xassembler -o "$$TMP" -,$(2),$(3))
+	printf "%b\n" "$(1)" | $(CC) $(KBUILD_AFLAGS) -c -xassembler -o "$$TMP" -,$(2),$(3))
 
 # cc-option
 # Usage: cflags-y += $(call cc-option,-march=winchip-c6,-march=i586)


### PR DESCRIPTION
The following error shows up when building on OS X:  `Error: selected processor does not support ARM mode 'smc #0'`.
It appears to be caused by `echo -e` in `scripts/Kbuild.include`. [Replacing `echo` with `printf` solves the problem](https://github.com/imoseyon/leanKernel-galaxy-nexus/pull/6).
